### PR TITLE
Fix/non orthogonal getrot

### DIFF
--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -29,6 +29,7 @@
 
 #define _USE_MATH_DEFINES  // For MSVC
 #include <math.h>
+#include <algorithm>
 
 namespace KDL {
 
@@ -439,7 +440,11 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
         return angle; // return 180 deg rotation
     }
 
-    angle = acos(( data[0] + data[4] + data[8] - 1)/2);
+    // If the matrix is slightly non-orthogonal, `f` may be out of the (-1, +1) range.
+    // Therefore, clamp it between those values to avoid NaNs.
+    double f = (data[0] + data[4] + data[8] - 1) / 2;
+    angle = acos(std::max(-1.0, std::min(1.0, f)));
+
     x = (data[7] - data[5]);
     y = (data[2] - data[6]);
     z = (data[3] - data[1]);

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -393,6 +393,19 @@ void FramesTest::TestRotation() {
 	TestOneRotation("rot([-1,-1,-1],180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,-1),180*deg2rad), 180*deg2rad, Vector(1,1,1)/sqrt(3.0));
 	// same as +180
 	TestOneRotation("rot([-1,-1,-1],-180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,-1),-180*deg2rad), 180*deg2rad, Vector(1,1,1)/sqrt(3.0));
+
+  // Test GetRotAngle on slightly non-orthogonal rotation matrices
+  {
+    Vector axis;
+    double angle = KDL::Rotation( 1, 0, 0 + 1e-6, 0, 1, 0, 0, 0,  1 + 1e-6).GetRotAngle(axis);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE("rot(NON-ORTHOGONAL, 0)", 0.0, angle, epsilon);
+  }
+
+  {
+    Vector axis;
+    double angle = KDL::Rotation(-1, 0, 0 + 1e-6, 0, 1, 0, 0, 0, -1 - 1e-6).GetRotAngle(axis);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE("rot(NON-ORTHOGONAL, PI)", M_PI, angle, epsilon);
+  }
 }
 
 void FramesTest::TestQuaternion() {


### PR DESCRIPTION
There was still a problem with the GetRotAngle method: in the case of slightly malformed rotation matrices (talking errors of 1e-6 or less), the method would sometimes produce NaNs. Fix it, and added two tests.