### PR TITLE
fix: remove hardcode python version

### DIFF
--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(orocos_kdl)
 include_directories(${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
-SET(PYTHON_VERSION 2 CACHE STRING "Python Version")
+
 find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} REQUIRED)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
The problem was that PyKDL was not build in python 3

To build both python 3 and 2 the hardcode to 2 is not needed.